### PR TITLE
Fix cropper preview image variable

### DIFF
--- a/BLS_Spain.html
+++ b/BLS_Spain.html
@@ -462,6 +462,7 @@
 
     <script>
         let cropper;
+        let previewImg;
         const translations = {
             en: {
                     title: "BLS Appointment Photo Formatter",
@@ -592,6 +593,7 @@
             const image = document.createElement('img');
             image.src = imageSrc;
             canvasContainer.appendChild(image);
+            previewImg = image;
 
             if (cropper) {
                 cropper.destroy();

--- a/BSL_Spain.html
+++ b/BSL_Spain.html
@@ -463,6 +463,7 @@
 
     <script>
         let cropper;
+        let previewImg;
         const translations = {
             en: {
                     title: "BLS Appointment Photo Formatter",
@@ -593,6 +594,7 @@
             const image = document.createElement('img');
             image.src = imageSrc;
             canvasContainer.appendChild(image);
+            previewImg = image;
 
             if (cropper) {
                 cropper.destroy();


### PR DESCRIPTION
## Summary
- declare a `previewImg` variable for cropper
- set `previewImg` when initializing the cropper
- use this variable during window resize

## Testing
- `node -e "const fs=require('fs'); const html=fs.readFileSync('BLS_Spain.html','utf8'); const code=html.split('<script>')[2].split('</script>')[0]; new Function(code);" && echo 'parsed'`
- `node -e "const fs=require('fs'); const html=fs.readFileSync('BSL_Spain.html','utf8'); const code=html.split('<script>')[2].split('</script>')[0]; new Function(code);" && echo 'parsed'`

------
https://chatgpt.com/codex/tasks/task_e_6862909f1aec832fb896f1f61843e57d